### PR TITLE
fix: draw is not a function error

### DIFF
--- a/src/components/dataviz.js
+++ b/src/components/dataviz.js
@@ -77,7 +77,11 @@ function DataViz () {
                     p.y = p.sy * (1 - i) + p.ty * i
                 })
                 draw()
-                (1 === i && (timer.stop(), currLayout = (currLayout + 1) % layouts.length, animate(layouts[currLayout])))
+                if (1 === i) {
+                    timer.stop()
+                    currLayout = (currLayout + 1) % layouts.length
+                    animate(layouts[currLayout])
+                }
             }
         )
     }
@@ -108,7 +112,7 @@ function DataViz () {
                 d3.select(this).style("display","none")
             })
         console.log('useEffect')
-    })
+    }, [])
     return (
         <>
             <div id="dataviz" ref={canvasRef}></div>


### PR DESCRIPTION
the issue you had was because you're not using semicolons and
```
draw()
(1 === i && (timer.stop(), currLayout = (currLayout + 1) % layouts.length, animate(layouts[currLayout])))
```

is the same as `draw()(1 === i && (timer.stop(), currLayout = (currLayout + 1) % layouts.length, animate(layouts[currLayout])))` which is faulty. Writing it with an if works fine for readability and fixes the issue.

A shorter fix would be
`draw(),(1 === i && (timer.stop(), currLayout = (currLayout + 1) % layouts.length, animate(layouts[currLayout])))`

I also added an empty update array to useEffect as you just want d3 initialization to be happening on mount and not on any prop updates. This currently wasn't an issue with your code but better safe than sorry.